### PR TITLE
Fix object URL cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,8 +543,14 @@
             showPreview(tex, gridType === 'source' ? state.activeSourcePackName : (tex.fromPack || 'Customized'));
           });
           // Clean up Object URL when image is no longer needed or if it errors
-          img.addEventListener('load', () => { /* URL.revokeObjectURL(objectURL); // Consider implications */ }, { once: true });
-          img.addEventListener('error', () => { if (objectURL.startsWith("blob:")) URL.revokeObjectURL(objectURL); }, { once: true });
+          img.addEventListener('load', () => {
+            if (objectURL.startsWith('blob:')) {
+              URL.revokeObjectURL(objectURL);
+            }
+          }, { once: true });
+          img.addEventListener('error', () => {
+            if (objectURL.startsWith('blob:')) URL.revokeObjectURL(objectURL);
+          }, { once: true });
 
           gridElement.appendChild(img);
         });


### PR DESCRIPTION
## Summary
- revoke object URLs after image load in grid renderer
- keep error handler cleanup

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6840c4e9563c832389743dd4057729b6